### PR TITLE
Little ecosystem tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+[*]
+charset = utf-8
+end_of_line = crlf
+
+[*.cs]
+
+# CS4014: Task not awaited
+dotnet_diagnostic.CS4014.severity = error
+
+# CS1998: Async function does not contain await
+dotnet_diagnostic.CS1998.severity = silent
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = silent
+ 
+# IDE0060: // Remove unused parameter 
+dotnet_diagnostic.IDE0060.severity = silent 
+ 
+# CS1066: // Optional parameter has no effect 
+dotnet_diagnostic.CS1066.severity = silent 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/WindowsFormsApp3.sln
+++ b/WindowsFormsApp3.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsFormsApp3", "WindowsFormsApp3\WindowsFormsApp3.csproj", "{31DE8678-6720-41F7-84AB-86EF06C0F44D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3038D69F-4559-42A7-9758-3553B6816C6A}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/WindowsFormsApp3/Form1.cs
+++ b/WindowsFormsApp3/Form1.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -170,15 +171,13 @@ namespace WindowsFormsApp3
             bitmap.Save(@"C:\debug\tamriel.bmp");
         }
 
-        public float[,] ParseHeights(ReadOnlyMemorySlice<byte> input_in)
+        public float[,] ParseHeights(ReadOnlyMemorySlice<byte> input)
         {
-            byte[] input = input_in.ToArray();
             float[,] returner = new float[32, 32];
-            float offset = BitConverter.ToSingle(input, 0);
-            float row_offset = 0;
+            float offset = BinaryPrimitives.ReadSingleLittleEndian(input);
             for (int r = 0; r < 32; r++)
             {
-                row_offset = 0;
+                var row_offset = 0f;
                 for (int c = 0; c < 32; c++)
                 {
                     sbyte pos = (sbyte)input[r * 32 + c];

--- a/WindowsFormsApp3/Form1.cs
+++ b/WindowsFormsApp3/Form1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Mutagen.Bethesda.Skyrim;
+using Noggog;
 
 namespace WindowsFormsApp3
 {
@@ -109,10 +110,12 @@ namespace WindowsFormsApp3
                     bool black = false;
                     foreach (var cell in subblock.Items)
                     {
+                        if (cell.Grid == null) continue;
                         int cell_x_normalized = cell.Grid.Point.X + 57; // -57 and -43 are the lowest numbers respectively
                         int cell_y_normalized = cell.Grid.Point.Y + 43;
-                        var land = cell.Landscape;
-                        float[,] heightmap = ParseHeights((Noggog.ReadOnlyMemorySlice<byte>)land.VertexHeightMap);
+                        if (!cell.Landscape.TryGet(out var land)
+                            || land.VertexHeightMap == null) continue;
+                        float[,] heightmap = ParseHeights(land.VertexHeightMap.Value);
                         for (int y = 0; y < 32; y++)
                         {
                             int rowoffsetbytes = (
@@ -167,7 +170,7 @@ namespace WindowsFormsApp3
             bitmap.Save(@"C:\debug\tamriel.bmp");
         }
 
-        public float[,] ParseHeights(Noggog.ReadOnlyMemorySlice<byte> input_in)
+        public float[,] ParseHeights(ReadOnlyMemorySlice<byte> input_in)
         {
             byte[] input = input_in.ToArray();
             float[,] returner = new float[32, 32];

--- a/WindowsFormsApp3/WindowsFormsApp3.csproj
+++ b/WindowsFormsApp3/WindowsFormsApp3.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mutagen.Bethesda" Version="0.24.0" />
-    <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.24.0" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.25.0" />
+    <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.25.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Enabled nullability concepts.  They're a core aspect of how Mutagen is exposed:
https://github.com/Mutagen-Modding/Mutagen/wiki/Nullability-to-Indicate-Record-Presence
- Adjusted the few usages that were interacting with nulls
- Bumped to the just released Mutagen version
- Upgraded ParseHeights span usage